### PR TITLE
fix `YoutubeDLWrapper` downloading

### DIFF
--- a/twitter_video_tools/utils/youtube_dl_wrapper.py
+++ b/twitter_video_tools/utils/youtube_dl_wrapper.py
@@ -8,14 +8,21 @@ from .execute_parallel import execute_parallel
 class YoutubeDLWrapper:    # pylint: disable=too-few-public-methods
     """A YoutubeDL wrapper class for supporting python embedded multi-processing"""
 
-    def _youtube_dl_download_video(self, link: str, youtube_dl_option: Optional[dict[str, str]] = None) -> None:
+    def _youtube_dl_download_video(
+        self,
+        link: str,
+        youtube_dl_option: Optional[dict[str, Union[str, int]]] = None,
+    ) -> None:
         with yt_dlp.YoutubeDL(youtube_dl_option) as youtube_dl_downloader:
             youtube_dl_downloader: yt_dlp.YoutubeDL
             youtube_dl_downloader.download([link])
 
     def download(self, links: list[str], youtube_dl_option: Optional[dict[str, Union[str, int]]] = None) -> None:
         arguments = [(link, youtube_dl_option) for link in links]
-        execute_parallel(self._youtube_dl_download_video, arguments)
+        if len(links) == 1:
+            self._youtube_dl_download_video(links[0], youtube_dl_option)
+        else:
+            execute_parallel(self._youtube_dl_download_video, arguments)
 
 
 youtube_dl_wrapper = YoutubeDLWrapper()    # singleton


### PR DESCRIPTION
Disables parallel downloading if link length is 1.
This prevents OSError from multiprocessing.
